### PR TITLE
Fixes memory corruption from pointer to array on stack

### DIFF
--- a/LedDisplay.cpp
+++ b/LedDisplay.cpp
@@ -51,8 +51,7 @@ LedDisplay::LedDisplay(uint8_t _dataPin,
 	this->resetPin = _resetPin;         		// the display's reset pin
 	this->displayLength = _displayLength;    	// number of bytes needed to pad the string
 	this->cursorPos = 0;						// position of the cursor in the display
-	char stringBuffer[displayLength+1];			// default array that the displayString will point to
-	
+
 	// fill stringBuffer with spaces, and a trailing 0:
 	for (int i = 0; i < displayLength; i++) {
 		stringBuffer[i] = ' ';

--- a/LedDisplay.h
+++ b/LedDisplay.h
@@ -93,9 +93,7 @@ class LedDisplay : public Print {
 																// be sent to the display by loadDotRegister()
 
   	int cursorPos;				// position of the cursor		
-//   	uint8_t dotRegister[40];    // the 320-bit dot register for a single 8 digit LED display
-// 	uint8_t dotRegister[80];    // the pair of 320-bit dot register for two 8 character LED displays
-   	uint8_t dotRegister[160];    // four 320-bit dot registers. 320 for each 8 character LED display 
+	uint8_t dotRegister[40];    // 5 bytes per character * up to 8 characters
 
 	// Define pins for the LED display:
 	uint8_t  dataPin;         	// connects to the display's data in

--- a/LedDisplay.h
+++ b/LedDisplay.h
@@ -102,6 +102,7 @@ class LedDisplay : public Print {
 	uint8_t chipEnable;       	// the display's chip enable pin
 	uint8_t resetPin;         	// the display's reset pin
 	uint8_t displayLength;    	// number of bytes needed to pad the string
+	char stringBuffer[9];     	// buffer to hold initial display string
 	char* displayString;		// string for scrolling
 };
 


### PR DESCRIPTION
This bug was seriously screwing with things, it allocates an array on the stack, saves a pointer to it, and continues to modify the location in memory after the function where the array was allocated has returned.