### PR TITLE
REQ:  Enable Blank Pin

### DIFF
--- a/LedDisplay.cpp
+++ b/LedDisplay.cpp
@@ -255,8 +255,8 @@ void LedDisplay::setBrightness(uint8_t bright)
  * 	set blank selection:
  * 	0 - default - pulled low
  * 	1 - high
- * 	2 - tri-state?
- * 	3 - PWM?
+ * 	2 - tri-state? tbd
+ * 	3 - PWM - set desired duty cycle on the blank pin
  * 	4 - PWM Test
  */
 

--- a/LedDisplay.cpp
+++ b/LedDisplay.cpp
@@ -28,11 +28,24 @@
 
 #include "LedDisplay.h"
 
+#define USING_PWM_LIB_FOR_TEST_PURPOSES
+#define DBG_PRINT_IN_LIB
+
 // Pascal Stang's 5x7 font library:
 #include "font5x7.h"
 // The font library is stored in program memory:
 #include <avr/pgmspace.h>
 #include <string.h>
+
+#ifdef USING_PWM_LIB_FOR_TEST_PURPOSES
+#include <SAMD21turboPWM.h>
+extern TurboPWM pwm;
+#endif
+
+static uint16_t dutyCycleLocal = 0;		// local duty cycle for PWM of blank signal for HCMS display
+static boolean dutyTestFlag = false;
+static uint8_t duty_step = 10;			// duty cycle step size - maybe make this a parameter?
+static uint16_t duty_MAX = 1000;		// set by lib at this time
 
 /*
  * 	Constructor.  Initializes the pins and the instance variables.
@@ -42,6 +55,7 @@ LedDisplay::LedDisplay(uint8_t _dataPin,
 					   uint8_t _clockPin,
 					   uint8_t _chipEnable,
 					   uint8_t _resetPin,
+					   uint8_t _blankPin,
 					   uint8_t _displayLength)
 {
 	// Define pins for the LED display:
@@ -50,6 +64,7 @@ LedDisplay::LedDisplay(uint8_t _dataPin,
 	this->clockPin = _clockPin;        			// the display's clock pin
 	this->chipEnable = _chipEnable;       		// the display's chip enable pin
 	this->resetPin = _resetPin;         		// the display's reset pin
+	this->blankPin = _blankPin;			// the display's blank pin
 	this->displayLength = _displayLength;    	// number of bytes needed to pad the string
 	this->cursorPos = 0;						// position of the cursor in the display
 
@@ -77,6 +92,7 @@ void LedDisplay::begin() {
   pinMode(clockPin, OUTPUT);
   pinMode(chipEnable, OUTPUT);
   pinMode(resetPin, OUTPUT);
+  pinMode(blankPin, OUTPUT);
 
   // reset the display:
   digitalWrite(resetPin, LOW);
@@ -233,6 +249,85 @@ void LedDisplay::setBrightness(uint8_t bright)
   
     // set the brightness:
     loadAllControlRegisters(B01110000 + bright);
+}
+
+/*
+ * 	set blank selection:
+ * 	0 - default - pulled low
+ * 	1 - high
+ * 	2 - tri-state?
+ * 	3 - PWM?
+ * 	4 - PWM Test
+ */
+
+void LedDisplay::setBlankPin(uint16_t blankSel, uint8_t dutyCycle)
+{
+
+	switch ( blankSel )
+	{
+
+		case 0:		// blank pulled low - this is default
+			digitalWrite(blankPin, LOW);
+			break;
+
+		case 1:
+			digitalWrite(blankPin, HIGH);
+			break;
+
+		case 2:				// tri-state possible?  Look at uC data sheet - TBD
+			break;
+
+		case 3:
+			pwm.analogWrite(blankPin, dutyCycle);  // requires PWM lib
+			break;
+
+//			static uint16_t dutyCycleLocal = 0;		// local duty cycle for PWM of blank signal for HCMS display
+//			static bool dutyTestFlag = FALSE;
+			
+
+		case 4:				// for testing - will cycle from dutyCycle passed - step, then back to zero - and wrap as long as called
+			if ( dutyTestFlag == false )
+			{
+				dutyCycleLocal = dutyCycle;
+				dutyTestFlag = true;	// doing dutyCycle test
+			//    pwm.analogWrite(blankPin, dutyCycleLocal);
+			//    dutyCycleLocal += duty_step;
+			}
+			if (dutyTestFlag)
+			{
+				pwm.analogWrite(blankPin, dutyCycleLocal);
+
+				dutyCycleLocal += duty_step;
+
+				if (dutyCycleLocal > duty_MAX )
+				{	
+					dutyCycleLocal = 0;
+				}
+
+				if ( dutyCycleLocal == dutyCycle )
+				{
+					dutyTestFlag = false;
+				}
+
+			}
+#ifdef DBG_PRINT_IN_LIB			
+			Serial.print(dutyCycleLocal);
+			Serial.println( " %");
+#endif			
+			break;
+			
+			    
+
+		default:
+			digitalWrite(blankPin, LOW);	// if we fall through
+			break;
+
+	}
+	
+#if 0
+    // 
+	loadAllControlRegisters(B01110000 + _);
+#endif	
 }
 
 

--- a/LedDisplay.h
+++ b/LedDisplay.h
@@ -59,6 +59,7 @@ class LedDisplay : public Print {
 			  uint8_t _clockPin,
 			  uint8_t _chipEnable,
 			  uint8_t _resetPin,
+			  uint8_t _blankPin,
 			  uint8_t _displayLength);
 
 
@@ -84,7 +85,7 @@ class LedDisplay : public Print {
 	void scroll(int direction);			// scroll whatever string is stored in library's displayString variable
 
 	void setBrightness(uint8_t bright);			// set display brightness, 0 - 15
-
+	void setBlankPin(uint16_t blankSel, uint8_t dutyCycle);
 	// Control register setters. for addressing the display directly:
 	void loadControlRegister(uint8_t dataByte);
 	void loadAllControlRegisters(uint8_t dataByte);
@@ -106,6 +107,7 @@ class LedDisplay : public Print {
 	uint8_t clockPin;         	// the display's clock pin
 	uint8_t chipEnable;       	// the display's chip enable pin
 	uint8_t resetPin;         	// the display's reset pin
+	uint8_t blankPin;		// the display's blank pin
 	uint8_t displayLength;    	// number of bytes needed to pad the string
 	char stringBuffer[LEDDISPLAY_MAXCHARS+1];  // buffer to hold initial display string
 	const char * displayString;	// string for scrolling

--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,7 @@ setString	KEYWORD2
 getString	KEYWORD2
 stringLength	KEYWORD2
 setBrightness	KEYWORD2
+setBlankPin	KEYWORD2
 writeCharacter	KEYWORD2
 loadControlRegister	KEYWORD2
 loadDotRegister	KEYWORD2

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ The displays have a synchronous serial interface. You'll need five digital outpu
     * clock - timing clock from the microcontroller
     * enable - enables or disables the display
     * reset - resets the display 
+    * blank - controls the diplay (on/off) and can set brightness (via PWM)
 
 The library manages all the necessary pin control and data shifting for you.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Adding features for the blank pin - including PWM (for experimental purposes) --
 
 For details, see http://www.arduino.cc/playground/Main/LedDisplay
 
-This library allows you to send text to an Avago HCMS-29xx LED display. The HCMS 29xx displays are pretty little displays that contain a row of 5x7 LED matrices. 
+This library allows you to send text to an Avago/Broadcom HCMS-29xx/HCMS-39xc LED MATRIX display. The HCMS 29xx/39xx displays are pretty little displays that contain a row of 5x7 LED matrices. 
 
 The displays have a synchronous serial interface. You'll need five digital output lines to control them. The pins are as follows:
 
@@ -13,7 +13,7 @@ The displays have a synchronous serial interface. You'll need five digital outpu
     * clock - timing clock from the microcontroller
     * enable - enables or disables the display
     * reset - resets the display 
-    * blank - controls the diplay (on/off) and can set brightness (via PWM)
+    * blank - controls the display (on/off) and can set brightness (via PWM)
 
 The library manages all the necessary pin control and data shifting for you.
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ LedDisplay(int dataPin, int registerSelect, int clockPin, int chipEnable, int re
 
 example:
 
-   LedDisplay myDisplay = LedDisplay(2,3,4,5,6,8);
+   LedDisplay myDisplay = LedDisplay(2,3,4,5,6,7,8);
 
 begin() - initializes and resets the display.
 
@@ -131,9 +131,25 @@ example:
 
    myDisplay.setBrightness(15);
 
+
+--==--
+
+/*
+ * 	set blankSel selection:
+ * 	0 - default - pulled low
+ * 	1 - high
+ * 	2 - tri-state? tbd
+ * 	3 - PWM - set desired duty cycle on the blank pin
+ * 	4 - PWM Test
+ */
+
 setBlankPin(int blankSel, char dutyCycle);
 
-example myDisplay.setBlankPin(4, 600);   --- this will select a PWM test mode starting at a duty cycle looping from 600 to 1000 and then resets at 0 to dutyCycle. Must be called periodically (like in loop()...).
+example:
+
+   myDisplay.setBlankPin(4, 600);   
+
+   --- this will select a PWM test mode starting at a duty cycle looping from 600 to 1000 and then resets at 0 to dutyCycle. Must be called periodically (like in loop()...).
 
 Can tie low, high, (maybe tri-state?), and set PWM (duty cycle) and duty cycle tests.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,7 @@
 LedDisplay Library
 
+Adding features for the blank pin - including PWM (for experimental purposes) --- jcw.
+
 For details, see http://www.arduino.cc/playground/Main/LedDisplay
 
 This library allows you to send text to an Avago HCMS-29xx LED display. The HCMS 29xx displays are pretty little displays that contain a row of 5x7 LED matrices. 
@@ -15,8 +17,8 @@ The displays have a synchronous serial interface. You'll need five digital outpu
 The library manages all the necessary pin control and data shifting for you.
 
 Methods:
-
-LedDisplay(int dataPin, int registerSelect, int clockPin, int chipEnable, int resetPin, int displayLength) - instantiates the library. The first five parameters are the Arduino pin numbers that are connected to the display. The last sets the length of the display (8 for the HCMS-291x and HCMS-297x, 4 for the HCMS-290x and 296x).
+ - blank pin added
+LedDisplay(int dataPin, int registerSelect, int clockPin, int chipEnable, int resetPin, int blankPin, int displayLength) - instantiates the library. The first five parameters are the Arduino pin numbers that are connected to the display. The last sets the length of the display (8 for the HCMS-291x and HCMS-297x, 4 for the HCMS-290x and 296x).
 
 example:
 
@@ -128,6 +130,15 @@ setBrightness(int bright) - lets you set the brightness from 0 to 15.
 example:
 
    myDisplay.setBrightness(15);
+
+setBlankPin(int blankSel, char dutyCycle);
+
+example myDisplay.setBlankPin(4, 600);   --- this will select a PWM test mode starting at a duty cycle looping from 600 to 1000 and then resets at 0 to dutyCycle. Must be called periodically (like in loop()...).
+
+Can tie low, high, (maybe tri-state?), and set PWM (duty cycle) and duty cycle tests.
+
+This is an alternative to the brightness control feature and something I wanted to test to see how it compares to just setting brightness with 4 bit value.
+
 
 If you want to set the opcodes of the display directly (you can learn them from the data sheet), the following methods will do the trick.
 


### PR DESCRIPTION
Hello All,

Since this appears to be working fairly well - I've decided to create a PR - note - since this is sortof an 'experiment' to see how well these HCMS displays respond to PWM control of the blank pin - I'm currently using the SAMD21turboPWM lib for PWM - and due to that - the PR checks may fail - and if it does fail, I will leave the PR in that state.  So, if the decision is made to move forward - then please just add having the SAMD21turboPWM as an installation requirement to have blank control for the HCMS series.

Thanks In Advance,
John W.
